### PR TITLE
Fix JSDoc types of optional parameters

### DIFF
--- a/docs/kintoneUtility.js
+++ b/docs/kintoneUtility.js
@@ -244,9 +244,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: getAllRecordsByQuery
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {array} params.fields
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {array} [params.fields]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1547,10 +1547,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: getRecords
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {array} params.fields
- *  @param {boolean} params.totalCount
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {array} [params.fields]
+ *  @param {boolean} [params.totalCount]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1598,8 +1598,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: postRecord
  *  @param {object} params
  *  @param {number} params.app
- *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {object} [params.record]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1656,7 +1656,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1710,13 +1710,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: putRecord
  *  @param {object} params
  *  @param {number} params.app
- *  @param {number} params.id
- *  @param {object} params.updateKey
+ *  @param {number} [params.id]
+ *  @param {object} [params.updateKey]
  *  @param {string} params.updateKey.field
  *  @param {string} params.updateKey.value
- *  @param {number} params.revision
- *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {number} [params.revision]
+ *  @param {object} [params.record]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1784,7 +1784,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1849,8 +1849,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.ids
- *  @param {array} params.revisions
- *  @param {boolean} params.isGuest
+ *  @param {array} [params.revisions]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -1915,7 +1915,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.ids
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -3963,7 +3963,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {number} params.id
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -4367,7 +4367,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -4444,7 +4444,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -4508,8 +4508,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *   Can delete over 2000 records, but can't do rollback.
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -4575,7 +4575,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {string} params.updateKey.field
  *  @param {string} params.updateKey.value
  *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -4646,7 +4646,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5229,7 +5229,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: downloadFile
  *  @param {object} params
  *  @param {string} params.fileKey
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5275,7 +5275,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {string} params.fileName
  *  @param {object} params.blob
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5321,9 +5321,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: getFormFields
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.lang
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {string} [params.lang]
+ *  @param {boolean} [params.isGuest]
+ *  @param {boolean} [params.isPreview]
  *
  *  @return {object} result
  */
@@ -5373,8 +5373,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: getFormLayout
  *  @param {object} params
  *  @param {number} params.app
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {boolean} [params.isGuest]
+ *  @param {boolean} [params.isPreview]
  *
  *  @return {object} result
  */
@@ -5422,9 +5422,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {object[]} params.apps
  *  @param {number} params.apps[].app
- *  @param {number?} params.apps[].revision
- *  @param {boolean?} params.revert
- *  @param {boolean?} params.isGuest
+ *  @param {number} [params.apps[].revision]
+ *  @param {boolean} [params.revert]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5473,7 +5473,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *  @param {object} params
  *  @param {object[]} params.apps
  *  @param {number} params.apps[].app
- *  @param {boolean?} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5518,8 +5518,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: getCustomization
  *  @param {object} params
  *  @param {number} params.app
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {boolean} [params.isPreview]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */
@@ -5566,25 +5566,25 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /** Function: updateCustomization
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string?} params.scope
- *  @param {object?} params.desktop
- *  @param {object[]?} params.desktop.js
+ *  @param {string} [params.scope]
+ *  @param {object} [params.desktop]
+ *  @param {object[]} [params.desktop.js]
  *  @param {string} params.desktop.js[].type
- *  @param {string?} params.desktop.js[].url
- *  @param {object?} params.desktop.js[].file
+ *  @param {string} [params.desktop.js[].url]
+ *  @param {object} [params.desktop.js[].file]
  *  @param {string} params.desktop.js[].file.fileKey
- *  @param {object[]?} params.desktop.css
+ *  @param {object[]} [params.desktop.css]
  *  @param {string} params.desktop.css[].type
- *  @param {string?} params.desktop.css[].url
- *  @param {object?} params.desktop.css[].file
+ *  @param {string} [params.desktop.css[].url]
+ *  @param {object} [params.desktop.css[].file]
  *  @param {string} params.desktop.css[].file.fileKey
- *  @param {object[]?} params.mobile.js
+ *  @param {object[]} [params.mobile.js]
  *  @param {string} params.mobile.js[].type
- *  @param {string?} params.mobile.js[].url
- *  @param {object?} params.mobile.js[].file
+ *  @param {string} [params.mobile.js[].url]
+ *  @param {object} [params.mobile.js[].file]
  *  @param {string} params.mobile.js[].file.fileKey
- *  @param {number?} params.revision
- *  @param {boolean?} params.isGuest
+ *  @param {number} [params.revision]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/deleteAllRecords.js
+++ b/src/js/rest/deleteAllRecords.js
@@ -9,7 +9,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.ids
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/deleteAllRecordsByQuery.js
+++ b/src/js/rest/deleteAllRecordsByQuery.js
@@ -5,8 +5,8 @@ import deleteAllRecords from './deleteAllRecords';
  *   Can delete over 2000 records, but can't do rollback.
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/deleteRecords.js
+++ b/src/js/rest/deleteRecords.js
@@ -10,8 +10,8 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.ids
- *  @param {array} params.revisions
- *  @param {boolean} params.isGuest
+ *  @param {array} [params.revisions]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/downloadFile.js
+++ b/src/js/rest/downloadFile.js
@@ -5,7 +5,7 @@ import sendRequest from './common/sendRequest';
 /** Function: downloadFile
  *  @param {object} params
  *  @param {string} params.fileKey
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getAllRecordsByQuery.js
+++ b/src/js/rest/getAllRecordsByQuery.js
@@ -6,9 +6,9 @@ import limit from './resource/limit.json';
 /** Function: getAllRecordsByQuery
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {array} params.fields
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {array} [params.fields]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getAppDeployStatus.js
+++ b/src/js/rest/getAppDeployStatus.js
@@ -6,7 +6,7 @@ import sendRequest from './common/sendRequest';
  *  @param {object} params
  *  @param {object[]} params.apps
  *  @param {number} params.apps[].app
- *  @param {boolean?} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getCustomization.js
+++ b/src/js/rest/getCustomization.js
@@ -5,8 +5,8 @@ import sendRequest from './common/sendRequest';
 /** Function: getCustomization
  *  @param {object} params
  *  @param {number} params.app
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {boolean} [params.isPreview]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getFormFields.js
+++ b/src/js/rest/getFormFields.js
@@ -5,9 +5,9 @@ import sendRequest from './common/sendRequest';
 /** Function: getFormFields
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.lang
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {string} [params.lang]
+ *  @param {boolean} [params.isGuest]
+ *  @param {boolean} [params.isPreview]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getFormLayout.js
+++ b/src/js/rest/getFormLayout.js
@@ -5,8 +5,8 @@ import sendRequest from './common/sendRequest';
 /** Function: getFormLayout
  *  @param {object} params
  *  @param {number} params.app
- *  @param {boolean} params.isGuest
- *  @param {boolean} params.isPreview
+ *  @param {boolean} [params.isGuest]
+ *  @param {boolean} [params.isPreview]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getRecord.js
+++ b/src/js/rest/getRecord.js
@@ -6,7 +6,7 @@ import sendRequest from './common/sendRequest';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {number} params.id
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/getRecords.js
+++ b/src/js/rest/getRecords.js
@@ -5,10 +5,10 @@ import sendRequest from './common/sendRequest';
 /** Function: getRecords
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string} params.query
- *  @param {array} params.fields
- *  @param {boolean} params.totalCount
- *  @param {boolean} params.isGuest
+ *  @param {string} [params.query]
+ *  @param {array} [params.fields]
+ *  @param {boolean} [params.totalCount]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/postAllRecords.js
+++ b/src/js/rest/postAllRecords.js
@@ -9,7 +9,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/postDeployAppSettings.js
+++ b/src/js/rest/postDeployAppSettings.js
@@ -6,9 +6,9 @@ import sendRequest from './common/sendRequest';
  *  @param {object} params
  *  @param {object[]} params.apps
  *  @param {number} params.apps[].app
- *  @param {number?} params.apps[].revision
- *  @param {boolean?} params.revert
- *  @param {boolean?} params.isGuest
+ *  @param {number} [params.apps[].revision]
+ *  @param {boolean} [params.revert]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/postRecord.js
+++ b/src/js/rest/postRecord.js
@@ -5,8 +5,8 @@ import sendRequest from './common/sendRequest';
 /** Function: postRecord
  *  @param {object} params
  *  @param {number} params.app
- *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {object} [params.record]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/postRecords.js
+++ b/src/js/rest/postRecords.js
@@ -10,7 +10,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/putAllRecords.js
+++ b/src/js/rest/putAllRecords.js
@@ -9,7 +9,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/putRecord.js
+++ b/src/js/rest/putRecord.js
@@ -5,13 +5,13 @@ import sendRequest from './common/sendRequest';
 /** Function: putRecord
  *  @param {object} params
  *  @param {number} params.app
- *  @param {number} params.id
- *  @param {object} params.updateKey
+ *  @param {number} [params.id]
+ *  @param {object} [params.updateKey]
  *  @param {string} params.updateKey.field
  *  @param {string} params.updateKey.value
- *  @param {number} params.revision
- *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {number} [params.revision]
+ *  @param {object} [params.record]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/putRecords.js
+++ b/src/js/rest/putRecords.js
@@ -10,7 +10,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/updateCustomization.js
+++ b/src/js/rest/updateCustomization.js
@@ -5,25 +5,25 @@ import sendRequest from './common/sendRequest';
 /** Function: updateCustomization
  *  @param {object} params
  *  @param {number} params.app
- *  @param {string?} params.scope
- *  @param {object?} params.desktop
- *  @param {object[]?} params.desktop.js
+ *  @param {string} [params.scope]
+ *  @param {object} [params.desktop]
+ *  @param {object[]} [params.desktop.js]
  *  @param {string} params.desktop.js[].type
- *  @param {string?} params.desktop.js[].url
- *  @param {object?} params.desktop.js[].file
+ *  @param {string} [params.desktop.js[].url]
+ *  @param {object} [params.desktop.js[].file]
  *  @param {string} params.desktop.js[].file.fileKey
- *  @param {object[]?} params.desktop.css
+ *  @param {object[]} [params.desktop.css]
  *  @param {string} params.desktop.css[].type
- *  @param {string?} params.desktop.css[].url
- *  @param {object?} params.desktop.css[].file
+ *  @param {string} [params.desktop.css[].url]
+ *  @param {object} [params.desktop.css[].file]
  *  @param {string} params.desktop.css[].file.fileKey
- *  @param {object[]?} params.mobile.js
+ *  @param {object[]} [params.mobile.js]
  *  @param {string} params.mobile.js[].type
- *  @param {string?} params.mobile.js[].url
- *  @param {object?} params.mobile.js[].file
+ *  @param {string} [params.mobile.js[].url]
+ *  @param {object} [params.mobile.js[].file]
  *  @param {string} params.mobile.js[].file.fileKey
- *  @param {number?} params.revision
- *  @param {boolean?} params.isGuest
+ *  @param {number} [params.revision]
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/uploadFile.js
+++ b/src/js/rest/uploadFile.js
@@ -6,7 +6,7 @@ import sendRequest from './common/sendRequest';
  *  @param {object} params
  *  @param {string} params.fileName
  *  @param {object} params.blob
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/upsertRecord.js
+++ b/src/js/rest/upsertRecord.js
@@ -11,7 +11,7 @@ import putRecord from './putRecord';
  *  @param {string} params.updateKey.field
  *  @param {string} params.updateKey.value
  *  @param {object} params.record
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */

--- a/src/js/rest/upsertRecords.js
+++ b/src/js/rest/upsertRecords.js
@@ -11,7 +11,7 @@ import limit from './resource/limit.json';
  *  @param {object} params
  *  @param {number} params.app
  *  @param {array} params.records
- *  @param {boolean} params.isGuest
+ *  @param {boolean} [params.isGuest]
  *
  *  @return {object} result
  */


### PR DESCRIPTION
kintoneUtility has JSDoc in the comments but it doesn't include information of optional parameters. That cause editors to fail type checking. 

This PR adds the optional parameter information to JSDoc according to [kintoneUtility document](https://github.com/kintone/kintoneUtility/blob/master/guides/rest_doc.md).

Here is an example of type checking error in JetBrains editor.

**Before:**
<img width="1165" alt="2018-10-21 19 18 39" src="https://user-images.githubusercontent.com/1425259/47265839-db751a80-d568-11e8-855b-d6130eacfe31.png">

**After:**
<img width="674" alt="2018-10-21 19 17 54" src="https://user-images.githubusercontent.com/1425259/47265840-ddd77480-d568-11e8-9af6-49e81147fad0.png">

See also: [Use JSDoc: @type](http://usejsdoc.org/tags-type.html)